### PR TITLE
Add null safety check for stageData in LoadingState

### DIFF
--- a/source/engine/states/LoadingState.hx
+++ b/source/engine/states/LoadingState.hx
@@ -290,7 +290,7 @@ class LoadingState extends MusicBeatState
 		preloadCharacter(player1, prefixVocals);
 		if (player2 != player1)
 			preloadCharacter(player2, prefixVocals);
-		if (!stageData.hide_girlfriend && gfVersion != player2 && gfVersion != player1)
+		if (!stageData?.hide_girlfriend && gfVersion != player2 && gfVersion != player1)
 			preloadCharacter(gfVersion);
 
 		if (!dontPreloadDefaultVoices && needsVoices)


### PR DESCRIPTION
Need to find other bugs to fix, since I've not tested this engine yet