### PR TITLE
Renamed Mobile Options to Mobile Settings on Settings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,7 +254,7 @@ jobs:
           zip -r "/home/runner/${{ env.PROJECT_NAME }}-BC-windows-arm64.zip" .
 
       - name: Publish The Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.0
         with:
           name: "0.9.0"
           tag_name: "0.9.0"

--- a/source/engine/mobile/options/MobileSettingsSubState.hx
+++ b/source/engine/mobile/options/MobileSettingsSubState.hx
@@ -4,7 +4,7 @@ import flixel.input.keyboard.FlxKey;
 import options.BaseOptionsMenu;
 import options.Option;
 
-class MobileOptionsSubState extends BaseOptionsMenu
+class MobileSettingsSubState extends BaseOptionsMenu
 {
 	#if FEATURE_MOBILE_CONTROLS
 	final exControlTypes:Array<String> = ["NONE", "SINGLE", "DOUBLE"];
@@ -14,8 +14,8 @@ class MobileOptionsSubState extends BaseOptionsMenu
 
 	public function new()
 	{
-		title = 'Mobile Options';
-		rpcTitle = 'Mobile Options Menu'; // for Discord Rich Presence, fuck it
+		title = 'Mobile Settings';
+		rpcTitle = 'Mobile Settings Menu'; // for Discord Rich Presence, fuck it
 
 		#if FEATURE_MOBILE_CONTROLS
 		option = new Option('Extra Controls', 'Select how many extra buttons you prefer to have?\nThey can be used for mechanics with LUA or HScript.',

--- a/source/engine/options/OptionsState.hx
+++ b/source/engine/options/OptionsState.hx
@@ -21,7 +21,7 @@ class OptionsState extends MusicBeatState
 		'Visuals and UI',
 		'Gameplay',
 		#if (mobile || FEATURE_MOBILE_CONTROLS)
-		'Mobile Options'
+		'Mobile'
 		#end
 	];
 	private var grpOptions:FlxTypedGroup<Alphabet>;
@@ -59,7 +59,7 @@ class OptionsState extends MusicBeatState
 				Funkin.switchState(NoteOffsetState);
 			#if (mobile || FEATURE_MOBILE_CONTROLS)
 			case 'Mobile Options':
-				switchSubState(mobile.options.MobileOptionsSubState);
+				switchSubState(mobile.options.MobileSettingsSubState);
 			#end
 		}
 	}


### PR DESCRIPTION
Updated softprops/action-gh-release to v3.0.0 due to Node.js 20 end-of-life warning

(I changed the name of “Mobile Options” to “Mobile Settings” because I don't think that name doesn't fit)